### PR TITLE
Allowed for Google 2.* API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"phpunit/phpunit": "4.*",
 		"guzzlehttp/guzzle": "4.*",
 		"sgh/pdfbox": "dev-master",
-		"google/apiclient": "1.*",
+		"google/apiclient": "1.*|2.*",
 		"symfony/finder": "2.*|3.*"
 	},
 	"scripts":


### PR DESCRIPTION
phpgearbox/pdf's requirement for Google api isn't satisfied by Google api's latest versions